### PR TITLE
BSV Kursangaben auf Grobprogramm

### DIFF
--- a/www/application/print/class/build_picasso.php
+++ b/www/application/print/class/build_picasso.php
@@ -91,7 +91,7 @@
 			$title = "Picasso - " . $this->data->camp->name;
 			
 			$pdf->SetFont('','B', 20); 
-			$pdf->SetXY( 20, 11 );
+			$pdf->SetXY( 20, 12 );
 			$pdf->drawTextBox( $title, $this->pw - 40, 10, 'C', 'M', 0 );
 		}
 		

--- a/www/application/print/class/data.php
+++ b/www/application/print/class/data.php
@@ -60,7 +60,7 @@
 		
 		function load_content()
 		{
-			$query = "SELECT user.*, dropdown.entry as funct FROM user, user_camp, dropdown WHERE user.id = user_camp.user_id AND user_camp.camp_id = " . $this->camp_id . " AND user_camp.function_id = dropdown.item_nr";
+			$query = "SELECT user.*, dropdown.entry as funct FROM user, user_camp, dropdown WHERE user.id = user_camp.user_id AND user_camp.camp_id = " . $this->camp_id . " AND user_camp.function_id = dropdown.id";
 			$result = mysql_query( $query );
 			while( $user = mysql_fetch_assoc( $result ) ){	$this->user[ $user['id'] ] = new print_data_user_class( $user, $this );	}
 			

--- a/www/application/print/class/data.php
+++ b/www/application/print/class/data.php
@@ -67,8 +67,8 @@
 			$query = "SELECT * FROM category WHERE camp_id = " . $this->camp_id;
 			$result = mysql_query( $query );
 			while( $category = mysql_fetch_assoc( $result ) ){	$this->category[ $category['id'] ] = new print_data_category_class( $category, $this );	}
-			
-			$query = "SELECT *, MIN( subcamp.start ) as first_day, MAX( subcamp.start + subcamp.length - 1 ) as last_day, job.job_name FROM camp, subcamp, job WHERE camp.id = subcamp.camp_id AND camp.id = " . $this->camp_id . " AND job.camp_id = camp.id AND job.show_gp = 1 GROUP BY camp.id";
+
+			$query = "SELECT *, MIN( subcamp.start ) as first_day, MAX( subcamp.start + subcamp.length - 1 ) as last_day, job.job_name, dropdown.entry as coursetype FROM camp, subcamp, job, dropdown WHERE camp.id = subcamp.camp_id AND camp.id = " . $this->camp_id . " AND job.camp_id = camp.id AND job.show_gp = 1 AND dropdown.value = camp.type GROUP BY camp.id";
 			$result = mysql_query( $query );
 			$this->camp = new print_data_camp_class( mysql_fetch_assoc( $result ), $this );
 			

--- a/www/application/print/class/data.php
+++ b/www/application/print/class/data.php
@@ -60,7 +60,7 @@
 		
 		function load_content()
 		{
-			$query = "SELECT user.* FROM user, user_camp WHERE user.id = user_camp.user_id AND user_camp.camp_id = " . $this->camp_id;
+			$query = "SELECT user.*, dropdown.entry as funct FROM user, user_camp, dropdown WHERE user.id = user_camp.user_id AND user_camp.camp_id = " . $this->camp_id . " AND user_camp.function_id = dropdown.item_nr";
 			$result = mysql_query( $query );
 			while( $user = mysql_fetch_assoc( $result ) ){	$this->user[ $user['id'] ] = new print_data_user_class( $user, $this );	}
 			

--- a/www/application/print/class/data_camp.php
+++ b/www/application/print/class/data_camp.php
@@ -25,6 +25,7 @@
 		public $pid;
 		public $id;
 		public $name;
+		public $short_name;
 		public $group_name;
 		public $slogan;
 		public $type;
@@ -46,6 +47,7 @@
 			$this->pid 			= $pid;
 			$this->id 			= $data['id'];
 			$this->name 		= $data['name'];
+			$this->short_name   = $data['short_name'];
 			$this->group_name	= $data['group_name'];
 			$this->slogan 		= $data['slogan'];
 			$this->type 		= $data['type'];

--- a/www/application/print/class/data_camp.php
+++ b/www/application/print/class/data_camp.php
@@ -30,6 +30,7 @@
 		public $slogan;
 		public $type;
 		public $is_course;
+		public $coursetype;
 		public $ca_name;
 		public $ca_street;
 		public $ca_zipcode;

--- a/www/application/print/class/data_camp.php
+++ b/www/application/print/class/data_camp.php
@@ -52,6 +52,7 @@
 			$this->slogan 		= $data['slogan'];
 			$this->type 		= $data['type'];
 			$this->is_course	= $data['is_course'];
+			$this->coursetype	= $data['coursetype'];
 			$this->ca_name 		= $data['ca_name'];
 			$this->ca_street 	= $data['ca_street'];
 			$this->ca_zipcode 	= $data['ca_zipcode'];

--- a/www/application/print/class/data_camp.php
+++ b/www/application/print/class/data_camp.php
@@ -47,7 +47,7 @@
 			$this->pid 			= $pid;
 			$this->id 			= $data['id'];
 			$this->name 		= $data['name'];
-			$this->short_name   = $data['short_name'];
+			$this->short_name	= $data['short_name'];
 			$this->group_name	= $data['group_name'];
 			$this->slogan 		= $data['slogan'];
 			$this->type 		= $data['type'];

--- a/www/application/print/class/data_user.php
+++ b/www/application/print/class/data_user.php
@@ -39,6 +39,7 @@
 		public $jsedu;
 		public $pbsedu;
 		public $image;
+		public $funct;
 		
 		
 		function print_data_user_class( $data, $pid )
@@ -60,6 +61,7 @@
 			$this->jsedu 		= $data['jsedu'];
 			$this->pbsedu 		= $data['pbsedu'];
 			$this->image 		= $data['image'];
+			$this->funct 		= $data['funct'];
 		}
 		
 		function get_name()

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -46,10 +46,12 @@
 						}
 					}
 					if (count($lkbs) > 0) {
-						$lkbs = implode(", ", $lkbs);
+						$lkbs = "LKB: " . implode(", ", $lkbs);
+					} else {
+						$lkbs = "";
 					}
 
-					$this->SetXY(10, 10);   $this->drawTextBox( 'LKB: ' . $lkbs, $w - 20, 4, 'L', 'T', 0);
+					$this->SetXY(10, 10);   $this->drawTextBox( $lkbs, $w - 20, 4, 'L', 'T', 0);
 					$this->SetXY(10, 10);  $this->drawTextBox( 'Kurstyp: ' . $print_data->camp->coursetype, $w - 20, 4, 'C', 'T', 0);
 				}
 				

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -15,7 +15,6 @@
 				$first_day = new c_date();		$first_day->setDay2000( $print_data->camp->first_day );
 				$last_day = new c_date();		$last_day->setDay2000( $print_data->camp->last_day );
 				
-				$main_leader = "";
 				$main_leaders = array();
 				foreach($print_data->user as $leader) {
 					if (($print_data->camp->is_course && $leader->funct == "Kursleiter") || (!$print_data->camp->is_course && $leader->funct == "Lagerleiter")) {
@@ -35,7 +34,7 @@
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $name_and_short_name, $w - 20, 4, 'R', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
-				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leader, $w - 20, 4, 'R', 'T', 0 );
+				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leaders, $w - 20, 4, 'R', 'T', 0 );
 				
 				$this->Line( 10, 10.5, $w - 10, 10.5 );
 				

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -23,6 +23,8 @@
 				}
 				if (count($main_leaders) > 0) {
 					$main_leaders = "Hauptleitung: " . implode(", ", $main_leaders);
+				} else {
+					$main_leaders = "";
 				}
 				
 				$w = $this->getPageWidth();

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -37,8 +37,23 @@
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leaders, $w - 20, 4, 'R', 'T', 0 );
+
+				if($print_data->camp->is_course){
+					$lkbs = array();
+					foreach($print_data->user as $lkb) {
+						if (($print_data->camp->is_course && $lkb->funct == "LKB")) {
+							$lkbs[] = $lkb->firstname . " " . $lkb->surname;
+						}
+					}
+					if (count($lkbs) > 0) {
+						$lkbs = implode(", ", $lkbs);
+					}
+
+					$this->SetXY(10, 10);   $this->drawTextBox( 'LKB: ' . $lkbs, $w - 20, 4, 'L', 'T', 0);
+					$this->SetXY(10, 10);  $this->drawTextBox( 'Kurstyp: ' . $print_data->camp->courstype, $w - 20, 4, 'C', 'T', 0);
+				}
 				
-				$this->Line( 10, 10.5, $w - 10, 10.5 );
+				$this->Line( 10, 14, $w - 10, 14 );
 				
 				$this->SetFontSize( $fs );
 				return;

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -16,11 +16,15 @@
 				$last_day = new c_date();		$last_day->setDay2000( $print_data->camp->last_day );
 				
 				$main_leader = "";
+				$main_leaders = array();
 				for ($i=0; $i<count($print_data->user); ++$i) {
 					$leader = $print_data->user[$i];
 					if (($print_data->camp->is_course && $leader->funct == "Kursleiter") || (!$print_data->camp->is_course && $leader->funct == "Lagerleiter")) {
-						$main_leader = "Hauptleitung: " . $leader->firstname . " " . $leader->surname;
+						$main_leaders[] = $leader->firstname . " " . $leader->surname;
 					}
+				}
+				if (count($main_leaders) > 0) {
+					$main_leaders = "Hauptleitung: " . implode(", ", $main_leaders);
 				}
 				
 				$w = $this->getPageWidth();

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -18,8 +18,9 @@
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->slogan, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->group_name, $w - 20, 4, 'L', 'T', 0 );
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->name, $w - 20, 4, 'R', 'T', 0 );
+				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
-				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_city, $w - 20, 4, 'R', 'T', 0 );
+				//$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_city, $w - 20, 4, 'R', 'T', 0 );
 				
 				$this->Line( 10, 10.5, $w - 10, 10.5 );
 				

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -7,6 +7,11 @@
 			{
 				global $print_data;
 				
+				$name_and_short_name = $print_data->camp->name;
+				if ($print_data->camp->is_course) {
+					$name_and_short_name = implode(", ", array($print_data->camp->name, $print_data->camp->short_name));
+				}
+
 				$first_day = new c_date();		$first_day->setDay2000( $print_data->camp->first_day );
 				$last_day = new c_date();		$last_day->setDay2000( $print_data->camp->last_day );
 				
@@ -24,7 +29,7 @@
 				
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->slogan, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->group_name, $w - 20, 4, 'L', 'T', 0 );
-				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->name, $w - 20, 4, 'R', 'T', 0 );
+				$this->SetXY( 10, 4 );		$this->drawTextBox( $name_and_short_name, $w - 20, 4, 'R', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leader, $w - 20, 4, 'R', 'T', 0 );

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -10,6 +10,13 @@
 				$first_day = new c_date();		$first_day->setDay2000( $print_data->camp->first_day );
 				$last_day = new c_date();		$last_day->setDay2000( $print_data->camp->last_day );
 				
+				$main_leader = "";
+				for ($i=0; $i<count($print_data->user); ++$i) {
+					$leader = $print_data->user[$i];
+					if (($print_data->camp->is_course && $leader->funct == "Kursleiter") || (!$print_data->camp->is_course && $leader->funct == "Lagerleiter")) {
+						$main_leader = "Hauptleitung: " . $leader->firstname . " " . $leader->surname;
+					}
+				}
 				
 				$w = $this->getPageWidth();
 				$fs = $this->getFontSize();
@@ -20,7 +27,7 @@
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $print_data->camp->name, $w - 20, 4, 'R', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
-				//$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_city, $w - 20, 4, 'R', 'T', 0 );
+				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leader, $w - 20, 4, 'R', 'T', 0 );
 				
 				$this->Line( 10, 10.5, $w - 10, 10.5 );
 				

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -50,7 +50,7 @@
 					}
 
 					$this->SetXY(10, 10);   $this->drawTextBox( 'LKB: ' . $lkbs, $w - 20, 4, 'L', 'T', 0);
-					$this->SetXY(10, 10);  $this->drawTextBox( 'Kurstyp: ' . $print_data->camp->courstype, $w - 20, 4, 'C', 'T', 0);
+					$this->SetXY(10, 10);  $this->drawTextBox( 'Kurstyp: ' . $print_data->camp->coursetype, $w - 20, 4, 'C', 'T', 0);
 				}
 				
 				$this->Line( 10, 14, $w - 10, 14 );

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -17,8 +17,7 @@
 				
 				$main_leader = "";
 				$main_leaders = array();
-				for ($i=0; $i<count($print_data->user); ++$i) {
-					$leader = $print_data->user[$i];
+				foreach($print_data->user as $leader) {
 					if (($print_data->camp->is_course && $leader->funct == "Kursleiter") || (!$print_data->camp->is_course && $leader->funct == "Lagerleiter")) {
 						$main_leaders[] = $leader->firstname . " " . $leader->surname;
 					}

--- a/www/application/print/tcpdf/tcpdf_addons.php
+++ b/www/application/print/tcpdf/tcpdf_addons.php
@@ -22,6 +22,9 @@
 					}
 				}
 				if (count($main_leaders) > 0) {
+					if (count($main_leaders) > 2) {
+						$main_leaders[floor(count($main_leaders) / 2)] = "\n" . $main_leaders[floor(count($main_leaders) / 2)];
+					}
 					$main_leaders = "Hauptleitung: " . implode(", ", $main_leaders);
 				} else {
 					$main_leaders = "";
@@ -36,7 +39,7 @@
 				$this->SetXY( 10, 4 );		$this->drawTextBox( $name_and_short_name, $w - 20, 4, 'R', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $print_data->camp->ca_name . ", " . $print_data->camp->ca_zipcode . " " . $print_data->camp->ca_city, $w - 20, 4, 'C', 'T', 0 );
 				$this->SetXY( 10, 7 );		$this->drawTextBox( $first_day->getString( 'd.m.Y' ) . " - " . $last_day->getString( 'd.m.Y' ), $w - 20, 4, 'L', 'T', 0 );
-				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leaders, $w - 20, 4, 'R', 'T', 0 );
+				$this->SetXY( 10, 7 );		$this->drawTextBox( $main_leaders, $w - 20, 8, 'R', 'T', 0 );
 
 				if($print_data->camp->is_course){
 					$lkbs = array();
@@ -56,6 +59,7 @@
 				}
 				
 				$this->Line( 10, 14, $w - 10, 14 );
+				$this->SetMargins(10,100, 10);
 				
 				$this->SetFontSize( $fs );
 				return;

--- a/www/template/application/camp/home.tpl
+++ b/www/template/application/camp/home.tpl
@@ -71,7 +71,10 @@
 								</td>
 							</tr>
 							<tr>
-                            	<td align="left">Kurzer Anzeigenamen:</td>
+								<td align="left">
+									<span tal:condition="not: camp/is_course">Kurzer Anzeigenamen:</span>
+									<span tal:condition="camp/is_course">Kursnummer:</span>
+								</td>
 								<td align="left">
 									<input type="text" name="value" id="camp_short_name" style="width: 100%" tal:attributes="value camp_info/short_name/value" />
 								</td>

--- a/www/template/application/camp_admin/new_camp.tpl
+++ b/www/template/application/camp_admin/new_camp.tpl
@@ -77,7 +77,7 @@
 				<tr>
 					<td>
 						<span tal:condition="not: course">Kurze Bezeichnung:</span>
-						<span tal:condition="course">Kurze Bezeichnung (z.B. Kurs-Nr.):</span>
+						<span tal:condition="course">Kursnummer:</span>
 					</td>
 					<td><input type="text" name="camp_short_name" id="camp_short_name" maxlength="15" style="width:170px"/></td>
 				</tr>


### PR DESCRIPTION
Gemäss PBS Anker muss bei Kursen auf dem Grobprogramm die Kursnummer, Kursbezeichnung (Basiskurs, Aufbaukurs, etc.), Kursort und Name des/der HKL stehen. Dieser Pull Request erreicht dies mit minimalen Änderungen an den PDFs. So kann von nun an der Picasso aus eCamp für die Kursmeldung beim BSV direkt verwendet werden, und muss nicht zuerst noch mit einem PDF-Editor um die fehlenden Angaben ergänzt werden.

- **Kursnummer**: Die Kurzbezeichnung bei Kursen wird umfunktioniert zu Kursnummer. Die Kurzbezeichnung wird auch bisher schon auf den PDFs angezeigt. Daher wurde nur die Feldbeschriftung in den "Infos zum Lager" angepasst (dies aber nur bei Kursen, nicht bei Lagern).
- **Kursbezeichnung**: Wird auch bisher schon auf den PDFs angezeigt.
- **Kursort**: Die Ortschaft wurde auch bisher schon angezeigt. Diese wurde aber in die Mitte des Headers verschoben, damit sie näher bei den Datumsangaben steht, und durch den Freitext-Namen aus den Lagerinfos ergänzt.
- **Name des/der HKL**: Dieser wird mit diesem PR zusätzlich in den PDF Header geschrieben.