### PR TITLE
Notizpapier Drucken

### DIFF
--- a/www/application/print/builder.php
+++ b/www/application/print/builder.php
@@ -25,7 +25,7 @@
 		$items = $_REQUEST['item'];
 		$conf  = $_REQUEST['conf'];
 	}
-	
+
 	ini_set("memory_limit","64M");
 	
 	require_once( 'class/data.php' );
@@ -48,9 +48,7 @@
 	$pdf->SetAuthor( 'ecamp2.pfadiluzern.ch' );
 	$pdf->SetSubject( 'J&S - Programm' );
 	$pdf->SetTitle( 'J&S - Programm' );
-	
-	
-	
+
 	foreach( $items as $nr => $item )
 	{
 		if( $item == "title" )
@@ -95,7 +93,14 @@
 		
 		if( $item == "toc" )
 		{	$print_build->toc->addTOC( $pdf );	}
-		
+
+		if( $item == "notes" )
+		{
+			for( $i = 1; $i <= $conf[$nr]; $i++){
+				$print_build->notes->build($pdf);
+			}
+		}
+
 		if( $item == "pdf" )
 		{
 			$file = $_FILES[$conf[$nr]];
@@ -123,7 +128,4 @@
 
 	
 	die();
-	
-	
-	
 ?>

--- a/www/application/print/class/build.php
+++ b/www/application/print/class/build.php
@@ -24,6 +24,7 @@
 	require_once( 'build_day.php' );
 	require_once( 'build_event.php' );
 	require_once( 'build_toc.php' );
+	require_once( 'build_notes.php' );
 	
 	
 	class print_build_class
@@ -37,6 +38,7 @@
 		public $day;
 		public $event;
 		public $toc;
+		public $notes;
 		
 		function print_build_class( $data )
 		{
@@ -48,6 +50,7 @@
 			$this->day		= new print_build_day_class( $this->data );
 			$this->event	= new print_build_event_class( $this->data );
 			$this->toc		= new print_build_toc();
+			$this->notes    = new print_build_notes();
 		}
 	}
 	

--- a/www/application/print/class/build_notes.php
+++ b/www/application/print/class/build_notes.php
@@ -1,0 +1,55 @@
+<?php
+	/*
+	 * Copyright (C) 2010 Urban Suppiger, Pirmin Mattmann
+	 *
+	 * This file is part of eCamp.
+	 *
+	 * eCamp is free software: you can redistribute it and/or modify
+	 * it under the terms of the GNU Affero General Public License as published by
+	 * the Free Software Foundation, either version 3 of the License, or
+	 * (at your option) any later version.
+	 *
+	 * eCamp is distributed in the hope that it will be useful,
+	 * but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 * GNU Affero General Public License for more details.
+	 *
+	 * You should have received a copy of the GNU Affero General Public License
+	 * along with eCamp.  If not, see <http://www.gnu.org/licenses/>.
+	 */
+
+
+	class print_build_notes
+	{
+		function build( $pdf )
+		{
+			$pdf->AddPage('P', 'A4');
+			$pdf->SetXY( 20, 12 );
+			$pdf->SetFont('','B',20);
+			$pdf->Cell( 170, 20, 'Notizen', 0, 1, 'C' );
+
+			$pdf->SetLineWidth(0.75);
+			$pdf->SetLineStyle(array('width' => 0.5, 'cap' => 'butt', 'dash' => 3));
+
+			// Linie zeichnen
+			$pdf->Line(15, 50, 195, 50);
+			$pdf->Line(15, 65, 195, 65);
+			$pdf->Line(15, 80, 195, 80);
+			$pdf->Line(15, 95, 195, 95);
+			$pdf->Line(15, 110, 195, 110);
+			$pdf->Line(15, 125, 195, 125);
+			$pdf->Line(15, 140, 195, 140);
+			$pdf->Line(15, 155, 195, 155);
+			$pdf->Line(15, 170, 195, 170);
+			$pdf->Line(15, 185, 195, 185);
+			$pdf->Line(15, 200, 195, 200);
+			$pdf->Line(15, 215, 195, 215);
+			$pdf->Line(15, 230, 195, 230);
+			$pdf->Line(15, 245, 195, 245);
+			$pdf->Line(15, 260, 195, 260);
+
+			$pdf->Bookmark( 'Notizen', 0, 0 );
+		}
+	}
+
+?>

--- a/www/public/application/print/js/main.js
+++ b/www/public/application/print/js/main.js
@@ -97,6 +97,12 @@ window.addEvent( 'domready', function()
 			
 			if( item.hasClass('toc') )
 			{	order.set( 'item[' + index + ']', 'toc' );	}
+
+            if( item.hasClass('notes') )
+            {
+            	order.set( 'item[' + index + ']', 'notes' );
+                order.set( 'conf[' + index + ']', item.getElement( 'input' ).get('value') );
+            }
 			
 			if( item.hasClass('pdf') )
 			{

--- a/www/template/application/print/libary.tpl
+++ b/www/template/application/print/libary.tpl
@@ -49,6 +49,14 @@
 			<li class="libary toc">
 				<h1>Inhaltsverzeichnis</h1>
 			</li>
+
+			<li class="libary notes">
+				<h1>Notizen</h1>
+				<p>
+					Anzahl Seiten Notizpapier:
+					<input type="number" name="notes" value="1" min="1" />
+				</p>
+			</li>
 			
 			<li class="libary pdf" tal:condition="true">
 				<h1>PDF</h1>


### PR DESCRIPTION
Notizpaier als Druck-Komponente implementieren.
Mit Hilfslinen fürs gerade schreiben.