### PR TITLE
reduce memory_limit to 16MB (except for printing and XLS generating)

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -9,5 +9,8 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 # increase max execution time
 RUN echo 'max_execution_time = 240' >> /usr/local/etc/php/conf.d/docker-php-maxexectime.ini;
 
+# limit memory to 16MB (same as production value in .user.ini)
+RUN echo 'memory_limit = 16M' >> /usr/local/etc/php/conf.d/docker-php-memorylimit.ini;
+
 # display all errors
 RUN echo 'error_reporting = E_ALL & ~E_NOTICE' >> /usr/local/etc/php/conf.d/error-logging.ini

--- a/src/application/aim/action_generate_xls.php
+++ b/src/application/aim/action_generate_xls.php
@@ -20,7 +20,7 @@
 	
 	# increase memory limit for generating xls
     # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
-	ini_set("memory_limit","32M");
+	ini_set("memory_limit","64M");
 	
 	// load data
 	$query = "SELECT CONCAT('(',v.day_nr,'.' ,v.event_nr,') ', e.name) AS name, 

--- a/src/application/aim/action_generate_xls.php
+++ b/src/application/aim/action_generate_xls.php
@@ -18,6 +18,10 @@
  * along with eCamp.  If not, see <http://www.gnu.org/licenses/>.
  */
 	
+	# increase memory limit for generating xls
+    # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
+	ini_set("memory_limit","32M");
+	
 	// load data
 	$query = "SELECT CONCAT('(',v.day_nr,'.' ,v.event_nr,') ', e.name) AS name, 
 				e.id AS id,

--- a/src/application/mat_list/action_generate_xls.php
+++ b/src/application/mat_list/action_generate_xls.php
@@ -20,7 +20,7 @@
 
 	# increase memory limit for generating xls
     # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
-	ini_set("memory_limit","32M");
+	ini_set("memory_limit","64M");
 	
 	/* load mat_list */
 	$list_id = $_REQUEST['list'];

--- a/src/application/mat_list/action_generate_xls.php
+++ b/src/application/mat_list/action_generate_xls.php
@@ -18,6 +18,10 @@
  * along with eCamp.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+	# increase memory limit for generating xls
+    # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
+	ini_set("memory_limit","32M");
+	
 	/* load mat_list */
 	$list_id = $_REQUEST['list'];
 	

--- a/src/application/print/builder.php
+++ b/src/application/print/builder.php
@@ -26,7 +26,10 @@
         $conf  = $_REQUEST['conf'];
     }
 
-    
+    # increase memory limit for printing
+    # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
+    ini_set("memory_limit","80M");
+
     require_once('class/data.php');
     require_once('class/build.php');
     require_once('include/fpdi_addons.php');

--- a/src/application/print/builder.php
+++ b/src/application/print/builder.php
@@ -28,7 +28,7 @@
 
     # increase memory limit for printing
     # keep overall memor_limit low to allow for more FPM processes per server (high WEB_CONCURRENCY)
-    ini_set("memory_limit","80M");
+    ini_set("memory_limit","64M");
 
     require_once('class/data.php');
     require_once('class/build.php');

--- a/src/public/.user.ini
+++ b/src/public/.user.ini
@@ -1,2 +1,4 @@
 error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
-memory_limit = 32M
+
+# lower memory limit = higher WEB_CONCURRENCY = more PHP-FPM processes
+memory_limit = 16M


### PR DESCRIPTION
General recommendation is to go with a lower memory limit (higher concurrency) and increase memory for specific script in runtime
See blue hint box on https://devcenter.heroku.com/articles/php-concurrency#runtime-changes-of-memory_limit

In worst case (many people printing in parallel and print script actually using the memory) the server could run out of memory and start paging. However, this should easily be visible in server statistics.

I was not able to reproduce out-of-memory exceptions for XLS generation. Not sure, if this really requires more memory or not.
