### PR TITLE
Fixes map onclick access issue

### DIFF
--- a/src/public/public/application/camp/js/home.js
+++ b/src/public/public/application/camp/js/home.js
@@ -95,6 +95,10 @@ window.addEvent('load', function()
 	
 	Map.addEventListener( 'mouseclick', function( e )
 	{
+		if(! auth.access(50)){
+			return;
+		}
+
 		mx1 = (e.mx / 1000).floor();
 		mx2 = e.mx - mx1 * 1000;
 		


### PR DESCRIPTION
This change will avoid the appearance of the coordinate-change-dialog if the user don't have right to change them.