### PR TITLE
prod revert

### DIFF
--- a/nginx_app.conf
+++ b/nginx_app.conf
@@ -9,5 +9,5 @@ location ~* favicon|apple-touch-icon|android-chrome-|mstile-|safari-pinned-tab.s
 
 location / {
 	index  index.php index.html index.htm;
-  fastcgi_read_timeout 300;
+  fastcgi_read_timeout 30;
 }

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -2,5 +2,3 @@
 ;log_level = debug
 ;[www]
 pm.max_requests = 1000
-request_terminate_timeout = 300
-php_admin_value[max_execution_time] = 300


### PR DESCRIPTION
Revert "Fix timeouts when generating pdf for large camps"

This reverts commit 46c08a42fdf05c79f9944f4e58d0aa92e55462c4. This did not help on production. We got an error 504 from digitalocean after 2 minutes. The actual print request takes several minutes and runs on after digitalocean has long cut off the connection to the browser. So this change only increases server load.

The .user.ini fix did help on the shared hosting, so we may just direct users with support requests to the shared hosting version for their last printing operations.